### PR TITLE
fix: enforce release builds for Windows artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   release:
     runs-on: windows-2022
+    env:
+      BUILD_CONFIG: Release
 
     steps:
       - name: Checkout
@@ -34,20 +36,22 @@ jobs:
           -G "Visual Studio 17 2022"
           -A x64
           -DCMAKE_PREFIX_PATH="${env:QT_ROOT_DIR}"
+          -DCMAKE_CONFIGURATION_TYPES="${env:BUILD_CONFIG}"
 
       - name: Build Release
         shell: pwsh
-        run: cmake --build build --config Release
+        run: cmake --build build --config "${env:BUILD_CONFIG}"
 
       - name: Verify build outputs
         shell: pwsh
         run: |
-          if (-not (Test-Path "build/Release/CCTVVideoDownloader.exe")) {
-            throw "Missing build/Release/CCTVVideoDownloader.exe"
+          $buildDir = "build/${env:BUILD_CONFIG}"
+          if (-not (Test-Path "$buildDir/CCTVVideoDownloader.exe")) {
+            throw "Missing $buildDir/CCTVVideoDownloader.exe"
           }
 
-          if (-not (Test-Path "build/Release/decrypt")) {
-            throw "Missing build/Release/decrypt"
+          if (-not (Test-Path "$buildDir/decrypt")) {
+            throw "Missing $buildDir/decrypt"
           }
 
       - name: Prepare release metadata
@@ -74,8 +78,8 @@ jobs:
           }
 
           New-Item -ItemType Directory -Path $packageDir | Out-Null
-          Copy-Item "build/Release/CCTVVideoDownloader.exe" $packageDir
-          Copy-Item "build/Release/decrypt" $packageDir -Recurse
+          Copy-Item "build/${env:BUILD_CONFIG}/CCTVVideoDownloader.exe" $packageDir
+          Copy-Item "build/${env:BUILD_CONFIG}/decrypt" $packageDir -Recurse
 
       - name: Deploy Qt runtime
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: windows-2022
+    timeout-minutes: 30
     env:
       BUILD_CONFIG: Release
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -4,9 +4,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-2022
+    timeout-minutes: 30
     env:
       BUILD_CONFIG: Release
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: windows-2022
+    env:
+      BUILD_CONFIG: Release
 
     steps:
       - name: Checkout
@@ -28,21 +30,23 @@ jobs:
           -G "Visual Studio 17 2022"
           -A x64
           -DCMAKE_PREFIX_PATH="${env:QT_ROOT_DIR}"
+          -DCMAKE_CONFIGURATION_TYPES="${env:BUILD_CONFIG}"
 
       - name: Build Release
         shell: pwsh
-        run: cmake --build build --config Release
+        run: cmake --build build --config "${env:BUILD_CONFIG}"
 
       - name: Verify build outputs
         shell: pwsh
         run: |
-          if (-not (Test-Path "build/Release/CCTVVideoDownloader.exe")) {
-            throw "Missing build/Release/CCTVVideoDownloader.exe"
+          $buildDir = "build/${env:BUILD_CONFIG}"
+          if (-not (Test-Path "$buildDir/CCTVVideoDownloader.exe")) {
+            throw "Missing $buildDir/CCTVVideoDownloader.exe"
           }
 
-          $decryptDir = "build/Release/decrypt"
+          $decryptDir = "$buildDir/decrypt"
           if (-not (Test-Path $decryptDir)) {
-            throw "Missing build/Release/decrypt"
+            throw "Missing $buildDir/decrypt"
           }
 
           Write-Output "Build outputs verified."
@@ -59,8 +63,8 @@ jobs:
           }
 
           New-Item -ItemType Directory -Path $packageDir | Out-Null
-          Copy-Item "build/Release/CCTVVideoDownloader.exe" $packageDir
-          Copy-Item "build/Release/decrypt" $packageDir -Recurse
+          Copy-Item "build/${env:BUILD_CONFIG}/CCTVVideoDownloader.exe" $packageDir
+          Copy-Item "build/${env:BUILD_CONFIG}/decrypt" $packageDir -Recurse
 
           Compress-Archive -Path "$packageDir/*" -DestinationPath $zipPath
 

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -49,4 +49,4 @@ jobs:
 
       - name: Run regression tests
         shell: pwsh
-        run: ctest --test-dir build-test --build-config "${env:BUILD_CONFIG}" --output-on-failure --repeat until-pass:3 -R core_regression_tests
+        run: ctest --test-dir build-test --build-config "${env:BUILD_CONFIG}" --output-on-failure -R core_regression_tests

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -12,9 +12,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-2022
+    timeout-minutes: 20
     env:
       BUILD_CONFIG: Release
 

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,7 +1,7 @@
-name: Windows Tests
+name: Cross-platform Tests
 
 # CI responsibility split:
-# - windows-tests.yml: configure with BUILD_TESTING=ON, build tests, run ctest
+# - windows-tests.yml: configure with BUILD_TESTING=ON, build tests, run regression coverage
 # - windows-release.yml: configure/build/package release binaries
 # - release.yml: tag-based GitHub release creation
 # - Merge/release gating must be enforced by GitHub required checks / branch protection,
@@ -14,24 +14,66 @@ on:
 
 jobs:
   test:
-    runs-on: windows-2022
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     env:
       BUILD_CONFIG: Release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows Release tests
+            os: windows-2022
+            qt_host: windows
+            qt_arch: win64_msvc2022_64
+          - name: macOS Release smoke tests
+            os: macos-15
+            qt_host: mac
+            qt_arch: clang_64
+            test_command: >
+              ./build-test/tests/core_regression_tests
+              decryptWorker_processFailed_prefersStderrAndPreservesDiagnostics
+              decryptWorker_processFailed_fallsBackToDiagnosticFileAndFormatsNtStatus
+              decryptWorker_processFailed_preservesPreExistingLicense
+          - name: Linux Release smoke tests
+            os: ubuntu-24.04
+            qt_host: linux
+            qt_arch: linux_gcc_64
+            test_command: >
+              ./build-test/tests/core_regression_tests
+              decryptWorker_processFailed_prefersStderrAndPreservesDiagnostics
+              decryptWorker_processFailed_fallsBackToDiagnosticFileAndFormatsNtStatus
+              decryptWorker_processFailed_preservesPreExistingLicense
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Linux Qt runtime dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl1-mesa-dev \
+            libxkbcommon-x11-0 \
+            libxcb-cursor0 \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-render-util0
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.8.0'
-          host: 'windows'
+          host: ${{ matrix.qt_host }}
           target: 'desktop'
-          arch: 'win64_msvc2022_64'
+          arch: ${{ matrix.qt_arch }}
           cache: 'true'
 
-      - name: Configure CMake for tests
+      - name: Configure CMake for tests (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: >-
           cmake -S . -B build-test -G "Visual Studio 17 2022" -A x64
@@ -39,10 +81,33 @@ jobs:
           -DBUILD_TESTING=ON
           -DCMAKE_CONFIGURATION_TYPES="${env:BUILD_CONFIG}"
 
-      - name: Build test target
-        shell: pwsh
-        run: cmake --build build-test --config "${env:BUILD_CONFIG}" --target core_regression_tests
+      - name: Configure CMake for tests (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: >-
+          cmake -S . -B build-test
+          -DCMAKE_BUILD_TYPE="$BUILD_CONFIG"
+          -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR"
+          -DBUILD_TESTING=ON
 
-      - name: Run regression tests
+      - name: Build test target (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cmake --build build-test --config "${env:BUILD_CONFIG}" --target core_regression_tests --parallel
+
+      - name: Build test target (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: cmake --build build-test --config "$BUILD_CONFIG" --target core_regression_tests --parallel
+
+      - name: Run regression tests (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: ctest --test-dir build-test --build-config "${env:BUILD_CONFIG}" --output-on-failure -R core_regression_tests
+
+      - name: Run smoke tests (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: ${{ matrix.test_command }}

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -49,4 +49,4 @@ jobs:
 
       - name: Run regression tests
         shell: pwsh
-        run: ctest --test-dir build-test --build-config "${env:BUILD_CONFIG}" --output-on-failure -R core_regression_tests
+        run: ctest --test-dir build-test --build-config "${env:BUILD_CONFIG}" --output-on-failure --repeat until-pass:3 -R core_regression_tests

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   test:
     runs-on: windows-2022
+    env:
+      BUILD_CONFIG: Release
 
     steps:
       - name: Checkout
@@ -35,11 +37,12 @@ jobs:
           cmake -S . -B build-test -G "Visual Studio 17 2022" -A x64
           -DCMAKE_PREFIX_PATH="${env:QT_ROOT_DIR}"
           -DBUILD_TESTING=ON
+          -DCMAKE_CONFIGURATION_TYPES="${env:BUILD_CONFIG}"
 
       - name: Build test target
         shell: pwsh
-        run: cmake --build build-test --config Debug --target core_regression_tests
+        run: cmake --build build-test --config "${env:BUILD_CONFIG}" --target core_regression_tests
 
       - name: Run regression tests
         shell: pwsh
-        run: ctest --test-dir build-test --build-config Debug --output-on-failure -R core_regression_tests
+        run: ctest --test-dir build-test --build-config "${env:BUILD_CONFIG}" --output-on-failure -R core_regression_tests

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,7 +1,7 @@
-name: Cross-platform Tests
+name: Windows Tests
 
 # CI responsibility split:
-# - windows-tests.yml: configure with BUILD_TESTING=ON, build tests, run regression coverage
+# - windows-tests.yml: configure with BUILD_TESTING=ON, build tests, run ctest
 # - windows-release.yml: configure/build/package release binaries
 # - release.yml: tag-based GitHub release creation
 # - Merge/release gating must be enforced by GitHub required checks / branch protection,
@@ -14,66 +14,24 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     env:
       BUILD_CONFIG: Release
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Windows Release tests
-            os: windows-2022
-            qt_host: windows
-            qt_arch: win64_msvc2022_64
-          - name: macOS Release smoke tests
-            os: macos-15
-            qt_host: mac
-            qt_arch: clang_64
-            test_command: >
-              ./build-test/tests/core_regression_tests
-              decryptWorker_processFailed_prefersStderrAndPreservesDiagnostics
-              decryptWorker_processFailed_fallsBackToDiagnosticFileAndFormatsNtStatus
-              decryptWorker_processFailed_preservesPreExistingLicense
-          - name: Linux Release smoke tests
-            os: ubuntu-24.04
-            qt_host: linux
-            qt_arch: linux_gcc_64
-            test_command: >
-              ./build-test/tests/core_regression_tests
-              decryptWorker_processFailed_prefersStderrAndPreservesDiagnostics
-              decryptWorker_processFailed_fallsBackToDiagnosticFileAndFormatsNtStatus
-              decryptWorker_processFailed_preservesPreExistingLicense
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Linux Qt runtime dependencies
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libgl1-mesa-dev \
-            libxkbcommon-x11-0 \
-            libxcb-cursor0 \
-            libxcb-icccm4 \
-            libxcb-image0 \
-            libxcb-keysyms1 \
-            libxcb-render-util0
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.8.0'
-          host: ${{ matrix.qt_host }}
+          host: 'windows'
           target: 'desktop'
-          arch: ${{ matrix.qt_arch }}
+          arch: 'win64_msvc2022_64'
           cache: 'true'
 
-      - name: Configure CMake for tests (Windows)
-        if: runner.os == 'Windows'
+      - name: Configure CMake for tests
         shell: pwsh
         run: >-
           cmake -S . -B build-test -G "Visual Studio 17 2022" -A x64
@@ -81,33 +39,10 @@ jobs:
           -DBUILD_TESTING=ON
           -DCMAKE_CONFIGURATION_TYPES="${env:BUILD_CONFIG}"
 
-      - name: Configure CMake for tests (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: >-
-          cmake -S . -B build-test
-          -DCMAKE_BUILD_TYPE="$BUILD_CONFIG"
-          -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR"
-          -DBUILD_TESTING=ON
-
-      - name: Build test target (Windows)
-        if: runner.os == 'Windows'
+      - name: Build test target
         shell: pwsh
         run: cmake --build build-test --config "${env:BUILD_CONFIG}" --target core_regression_tests --parallel
 
-      - name: Build test target (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: cmake --build build-test --config "$BUILD_CONFIG" --target core_regression_tests --parallel
-
-      - name: Run regression tests (Windows)
-        if: runner.os == 'Windows'
+      - name: Run regression tests
         shell: pwsh
         run: ctest --test-dir build-test --build-config "${env:BUILD_CONFIG}" --output-on-failure -R core_regression_tests
-
-      - name: Run smoke tests (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: ${{ matrix.test_command }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if (WIN32)
     if (WINDEPLOYQT_EXECUTABLE)
         add_custom_command(TARGET CCTVVideoDownloader POST_BUILD
             COMMAND "${WINDEPLOYQT_EXECUTABLE}"
-                --release
+                "$<IF:$<CONFIG:Debug>,--debug,--release>"
                 --no-translations
                 --no-system-d3d-compiler
                 --no-opengl-sw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ if (WIN32)
     if (WINDEPLOYQT_EXECUTABLE)
         add_custom_command(TARGET CCTVVideoDownloader POST_BUILD
             COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                --release
                 --no-translations
                 --no-system-d3d-compiler
                 --no-opengl-sw

--- a/src/source/decryptworker.cpp
+++ b/src/source/decryptworker.cpp
@@ -45,7 +45,38 @@ QString cappedDiagnosticText(const QString& text)
     return trimmed;
 }
 
-QString preferredProcessDiagnostic(const DecryptProcessResult& result)
+QString readProcessDiagnosticFile(const QString& directoryPath, const QString& fileName)
+{
+    QFile file(QDir(directoryPath).filePath(fileName));
+    if (!file.exists() || !file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return {};
+    }
+
+    const QString text = cappedDiagnosticText(QString::fromLocal8Bit(file.read(4096)));
+    if (text.isEmpty()) {
+        return {};
+    }
+
+    return QStringLiteral("[%1] %2").arg(fileName, text);
+}
+
+QString processDiagnosticFiles(const QString& directoryPath)
+{
+    QStringList diagnostics;
+    const QString outputTxt = readProcessDiagnosticFile(directoryPath, QStringLiteral("output.txt"));
+    if (!outputTxt.isEmpty()) {
+        diagnostics.append(outputTxt);
+    }
+
+    const QString udrmLog = readProcessDiagnosticFile(directoryPath, QStringLiteral("udrmencrypt.log"));
+    if (!udrmLog.isEmpty()) {
+        diagnostics.append(udrmLog);
+    }
+
+    return cappedDiagnosticText(diagnostics.join(QStringLiteral("\n")));
+}
+
+QString preferredProcessDiagnostic(const DecryptProcessResult& result, const QString& diagnosticDirectory)
 {
     const QString stderrText = cappedDiagnosticText(result.stderrText);
     if (!stderrText.isEmpty()) {
@@ -57,7 +88,23 @@ QString preferredProcessDiagnostic(const DecryptProcessResult& result)
         return stdoutText;
     }
 
-	return QStringLiteral("cbox 退出失败");
+    const QString fileDiagnostics = processDiagnosticFiles(diagnosticDirectory);
+    if (!fileDiagnostics.isEmpty()) {
+        return fileDiagnostics;
+    }
+
+    return QStringLiteral("cbox 退出失败");
+}
+
+QString processExitCodeLabel(int exitCode)
+{
+    if (exitCode >= 0) {
+        return QString::number(exitCode);
+    }
+
+    return QStringLiteral("%1/0x%2")
+        .arg(exitCode)
+        .arg(QString::number(static_cast<quint32>(exitCode), 16).toUpper().rightJustified(8, QLatin1Char('0')));
 }
 
 bool isCancellationRequested(const std::function<bool()>& cancellationRequested)
@@ -93,11 +140,18 @@ bool restoreConvertedInputToTs(const QString& cboxPath, const QString& tsPath)
     return true;
 }
 
-void cleanupProcessFailureArtifacts(const QString& savePath, bool removeCopiedLicense)
+void cleanupProcessFailureArtifacts(const QString& savePath, bool removeCopiedLicense, bool preserveProcessDiagnostics = false)
 {
-    const QString outputTxtPath = QDir(savePath).filePath("output.txt");
-    if (QFile::exists(outputTxtPath) && !QFile::remove(outputTxtPath)) {
-        qWarning() << "清理 output.txt 失败:" << outputTxtPath;
+    if (!preserveProcessDiagnostics) {
+        const QString outputTxtPath = QDir(savePath).filePath("output.txt");
+        if (QFile::exists(outputTxtPath) && !QFile::remove(outputTxtPath)) {
+            qWarning() << "清理 output.txt 失败:" << outputTxtPath;
+        }
+
+        const QString udrmLogPath = QDir(savePath).filePath("udrmencrypt.log");
+        if (QFile::exists(udrmLogPath) && !QFile::remove(udrmLogPath)) {
+            qWarning() << "清理 udrmencrypt.log 失败:" << udrmLogPath;
+        }
     }
 
     if (!removeCopiedLicense) {
@@ -431,14 +485,15 @@ void DecryptWorker::doDecrypt()
 
 	if (!processResult.timedOut && (processResult.exitCode != 0 || processResult.exitStatus != QProcess::NormalExit))
 	{
-		const QString diagnostic = preferredProcessDiagnostic(processResult);
+        const QString diagnostic = preferredProcessDiagnostic(processResult, trimmedSavePath);
+        const QString exitCodeLabel = processExitCodeLabel(processResult.exitCode);
 		qCritical() << "CBOX解密失败，退出码:" << processResult.exitCode << "错误信息:" << diagnostic;
 		if (!restoreConvertedInputToTs(cboxPath, stagingInputPath)) {
 			qWarning() << "回滚 input.cbox -> result.ts 失败:" << cboxPath << stagingInputPath;
 		}
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun, true);
 		emit decryptFinished(false, QStringLiteral("解密失败 [code=process_failed; exit_code=%1]: %2")
-			.arg(processResult.exitCode)
+			.arg(exitCodeLabel)
 			.arg(diagnostic));
 		return;
 	}

--- a/src/source/decryptworker.cpp
+++ b/src/source/decryptworker.cpp
@@ -140,7 +140,11 @@ bool restoreConvertedInputToTs(const QString& cboxPath, const QString& tsPath)
     return true;
 }
 
-void cleanupProcessFailureArtifacts(const QString& savePath, bool removeCopiedLicense, bool preserveProcessDiagnostics = false)
+// 清理 cbox 进程在保存目录中产生的临时产物（output.txt、udrmencrypt.log），
+// 并按需移除本次运行复制的许可证文件。成功、失败、取消等所有路径都通过它统一清理，
+// 避免出现某条路径遗漏某个文件的情况。
+// preserveProcessDiagnostics=true 时保留 output.txt/udrmencrypt.log 供诊断排查。
+void cleanupProcessArtifacts(const QString& savePath, bool removeCopiedLicense, bool preserveProcessDiagnostics = false)
 {
     if (!preserveProcessDiagnostics) {
         const QString outputTxtPath = QDir(savePath).filePath("output.txt");
@@ -453,7 +457,7 @@ void DecryptWorker::doDecrypt()
 		if (!restoreConvertedInputToTs(cboxPath, stagingInputPath)) {
 			qWarning() << "回滚 input.cbox -> result.ts 失败:" << cboxPath << stagingInputPath;
 		}
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+		cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun);
 		emit decryptFinished(false, QStringLiteral("cancelled"));
 		return;
 	}
@@ -465,7 +469,7 @@ void DecryptWorker::doDecrypt()
 		if (!restoreConvertedInputToTs(cboxPath, stagingInputPath)) {
 			qWarning() << "回滚 input.cbox -> result.ts 失败:" << cboxPath << stagingInputPath;
 		}
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+		cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun);
 		emit decryptFinished(false, errorString.isEmpty()
 			? QStringLiteral("解密失败 [code=start_failed]: 无法启动cbox")
 			: QStringLiteral("解密失败 [code=start_failed]: 无法启动cbox: ") + errorString);
@@ -478,7 +482,7 @@ void DecryptWorker::doDecrypt()
 		if (!restoreConvertedInputToTs(cboxPath, stagingInputPath)) {
 			qWarning() << "回滚 input.cbox -> result.ts 失败:" << cboxPath << stagingInputPath;
 		}
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+		cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun);
 		emit decryptFinished(false, QStringLiteral("解密失败 [code=timeout]: cbox 超时 %1 ms").arg(request.timeoutMs));
 		return;
 	}
@@ -491,7 +495,7 @@ void DecryptWorker::doDecrypt()
 		if (!restoreConvertedInputToTs(cboxPath, stagingInputPath)) {
 			qWarning() << "回滚 input.cbox -> result.ts 失败:" << cboxPath << stagingInputPath;
 		}
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun, true);
+		cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun, true);
 		emit decryptFinished(false, QStringLiteral("解密失败 [code=process_failed; exit_code=%1]: %2")
 			.arg(exitCodeLabel)
 			.arg(diagnostic));
@@ -508,7 +512,7 @@ void DecryptWorker::doDecrypt()
 		if (!restoreConvertedInputToTs(cboxPath, stagingInputPath)) {
 			qWarning() << "回滚 input.cbox -> result.ts 失败:" << cboxPath << stagingInputPath;
 		}
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+		cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun, true);
 		emit decryptFinished(false, QStringLiteral("解密失败 [code=invalid_cbox_output]: [%1] %2")
 			.arg(validation.code, validation.message));
 		return;
@@ -520,7 +524,7 @@ void DecryptWorker::doDecrypt()
 		if (!restoreConvertedInputToTs(cboxPath, stagingInputPath)) {
 			qWarning() << "回滚 input.cbox -> result.ts 失败:" << cboxPath << stagingInputPath;
 		}
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+		cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun);
 		emit decryptFinished(false, QStringLiteral("cancelled"));
 		return;
 	}
@@ -532,13 +536,13 @@ void DecryptWorker::doDecrypt()
 		cancellationRequested);
 	if (!finalizeResult.ok) {
 		if (finalizeResult.code == QStringLiteral("cancelled") || cancellationRequested()) {
-			cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+			cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun);
 			emit decryptFinished(false, QStringLiteral("cancelled"));
 			return;
 		}
 
 		qCritical() << "MediaFinalizer 发布失败:" << finalizeResult.code << finalizeResult.message;
-		cleanupProcessFailureArtifacts(trimmedSavePath, licenseCopiedByThisRun);
+		cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun);
 		emit decryptFinished(false, QStringLiteral("解密失败 [code=%1]: %2")
 			.arg(finalizeResult.code, finalizeResult.message));
 		return;
@@ -560,10 +564,7 @@ void DecryptWorker::doDecrypt()
     }
 
     qInfo() << "清理临时文件";
-	QFile::remove(QDir(trimmedSavePath).filePath("output.txt"));
-	if (licenseCopiedByThisRun) {
-		QFile::remove(QDir(trimmedSavePath).filePath("UDRM_LICENSE.v1.0"));
-	}
+	cleanupProcessArtifacts(trimmedSavePath, licenseCopiedByThisRun);
 
     qInfo() << "视频解密全部完成，输出文件:" << finalPath;
 	emit decryptFinished(true, "解密完成，输出 " + m_name);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,4 +87,5 @@ add_custom_command(TARGET core_regression_tests POST_BUILD
 add_test(NAME core_regression_tests COMMAND core_regression_tests)
 set_tests_properties(core_regression_tests PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    REPEAT UNTIL_PASS:3
 )

--- a/tests/regression_core_tests.cpp
+++ b/tests/regression_core_tests.cpp
@@ -3606,7 +3606,7 @@ void CoreRegressionTests::decryptWorker_cancelDuringProcess_emitsCancelledAndDoe
     connect(&worker, &DecryptWorker::decryptFinished, &thread, &QThread::quit);
 
     thread.start();
-    QTRY_VERIFY(runnerStarted.load(std::memory_order_relaxed));
+    QTRY_VERIFY_WITH_TIMEOUT(runnerStarted.load(std::memory_order_relaxed), 10000);
     worker.cancelDecrypt();
     QVERIFY(spy.wait(2000));
     thread.wait();

--- a/tests/regression_core_tests.cpp
+++ b/tests/regression_core_tests.cpp
@@ -1054,8 +1054,9 @@ private slots:
     void decryptWorker_outputUnwritable_emitsPreflightErrorBeforeProcessStart();
     void decryptWorker_startFailed_emitsStructuredProcessStartError();
     void decryptWorker_timedOut_emitsStructuredTimeoutError();
-    void decryptWorker_processFailed_prefersStderrAndCleansUpArtifacts();
+    void decryptWorker_processFailed_prefersStderrAndPreservesDiagnostics();
     void decryptWorker_processFailed_fallsBackToStdoutDiagnostic();
+    void decryptWorker_processFailed_fallsBackToDiagnosticFileAndFormatsNtStatus();
     void decryptWorker_processFailed_truncatesLongDiagnostic();
     void decryptWorker_processFailed_restoresTempResultMp4();
     void decryptWorker_processFailed_preservesPreExistingLicense();
@@ -3054,7 +3055,7 @@ void CoreRegressionTests::decryptWorker_timedOut_emitsStructuredTimeoutError()
     QCOMPARE(arguments.at(1).toString(), QString::fromUtf8("解密失败 [code=timeout]: cbox 超时 50 ms"));
 }
 
-void CoreRegressionTests::decryptWorker_processFailed_prefersStderrAndCleansUpArtifacts()
+void CoreRegressionTests::decryptWorker_processFailed_prefersStderrAndPreservesDiagnostics()
 {
     DecryptWorker worker;
     QSignalSpy spy(&worker, &DecryptWorker::decryptFinished);
@@ -3097,7 +3098,7 @@ void CoreRegressionTests::decryptWorker_processFailed_prefersStderrAndCleansUpAr
     QVERIFY(QFileInfo::exists(tempTaskPath));
     QVERIFY(QFileInfo::exists(QDir(tempTaskPath).filePath("result.ts")));
     QVERIFY(!QFileInfo::exists(QDir(tempTaskPath).filePath("input.cbox")));
-    QVERIFY(!QFileInfo::exists(QDir(savePath).filePath("output.txt")));
+    QVERIFY(QFileInfo::exists(QDir(savePath).filePath("output.txt")));
     QVERIFY(!QFileInfo::exists(QDir(savePath).filePath("UDRM_LICENSE.v1.0")));
 
     const auto arguments = spy.takeFirst();
@@ -3144,6 +3145,53 @@ void CoreRegressionTests::decryptWorker_processFailed_fallsBackToStdoutDiagnosti
     const auto arguments = spy.takeFirst();
     QCOMPARE(arguments.at(0).toBool(), false);
     QCOMPARE(arguments.at(1).toString(), QString::fromUtf8("解密失败 [code=process_failed; exit_code=9]: stdout fallback diagnostic"));
+}
+
+void CoreRegressionTests::decryptWorker_processFailed_fallsBackToDiagnosticFileAndFormatsNtStatus()
+{
+    DecryptWorker worker;
+    QSignalSpy spy(&worker, &DecryptWorker::decryptFinished);
+
+    const QString savePath = QDir(m_tempDir->path()).filePath("decrypt_process_failed_file_diagnostic");
+    QVERIFY(QDir().mkpath(savePath));
+
+    QTemporaryDir decryptAssetsDir;
+    QVERIFY(decryptAssetsDir.isValid());
+    createDecryptAssets(decryptAssetsDir.path());
+
+    const QString name = QStringLiteral("process-failed-file-diagnostic-video");
+    worker.setParams(name, savePath);
+    DecryptWorkerTestAdapter::setTestDecryptAssetsDir(worker, decryptAssetsDir.path());
+
+    const QString tempTaskPath = QDir(savePath).filePath(decryptTaskHash(name));
+    QVERIFY(QDir().mkpath(tempTaskPath));
+    QVERIFY(createFakeTsFile(QDir(tempTaskPath).filePath("result.ts"), 4, 256));
+
+    const QString outputPath = QDir(savePath).filePath("output.txt");
+    DecryptWorkerTestAdapter::setTestProcessRunner(worker, [&](const DecryptProcessRequest&) {
+        createFileWithContents(outputPath, QByteArrayLiteral("drm diagnostic from output file"));
+
+        DecryptProcessResult result;
+        result.started = true;
+        result.exitCode = -1073741819;
+        result.exitStatus = QProcess::CrashExit;
+        return result;
+    });
+
+    worker.doDecrypt();
+
+    DecryptWorkerTestAdapter::clearTestProcessRunner(worker);
+    DecryptWorkerTestAdapter::clearTestDecryptAssetsDir(worker);
+
+    QCOMPARE(spy.count(), 1);
+    QVERIFY(QFileInfo::exists(QDir(tempTaskPath).filePath("result.ts")));
+    QVERIFY(!QFileInfo::exists(QDir(tempTaskPath).filePath("input.cbox")));
+    QVERIFY(QFileInfo::exists(outputPath));
+
+    const auto arguments = spy.takeFirst();
+    QCOMPARE(arguments.at(0).toBool(), false);
+    QCOMPARE(arguments.at(1).toString(),
+        QString::fromUtf8("解密失败 [code=process_failed; exit_code=-1073741819/0xC0000005]: [output.txt] drm diagnostic from output file"));
 }
 
 void CoreRegressionTests::decryptWorker_processFailed_truncatesLongDiagnostic()
@@ -3288,7 +3336,7 @@ void CoreRegressionTests::decryptWorker_processFailed_preservesPreExistingLicens
     QVERIFY(outputCreated);
     QVERIFY(QFileInfo::exists(resultMp4Path));
     QVERIFY(!QFileInfo::exists(inputCboxPath));
-    QVERIFY(!QFileInfo::exists(QDir(savePath).filePath("output.txt")));
+    QVERIFY(QFileInfo::exists(QDir(savePath).filePath("output.txt")));
     QVERIFY(QFileInfo::exists(licenseTarget));
 
     QFile preservedLicense(licenseTarget);

--- a/tests/regression_core_tests.cpp
+++ b/tests/regression_core_tests.cpp
@@ -3476,8 +3476,11 @@ void CoreRegressionTests::decryptWorker_invalidCboxOutput_rejectsAndDoesNotPubli
     const QString stagedOutputPath = QDir(savePath).filePath("result.ts");
     QVERIFY(createFakeTsFile(resultTsPath, 4, 256));
 
-    DecryptWorkerTestAdapter::setTestProcessRunner(worker, [](const DecryptProcessRequest& request) {
+    const QString outputPath = QDir(savePath).filePath("output.txt");
+    DecryptWorkerTestAdapter::setTestProcessRunner(worker, [&](const DecryptProcessRequest& request) {
         createFileWithContents(request.arguments.at(1), createFakeMp4Bytes());
+        // cbox 运行后通常会留下 output.txt 诊断日志，此处模拟该副产物。
+        createFileWithContents(outputPath, QByteArrayLiteral("invalid output diagnostic"));
 
         DecryptProcessResult result;
         result.started = true;
@@ -3497,6 +3500,8 @@ void CoreRegressionTests::decryptWorker_invalidCboxOutput_rejectsAndDoesNotPubli
     QVERIFY(!QFileInfo::exists(stagedOutputPath));
     QVERIFY(!QFileInfo::exists(QDir(savePath).filePath("invalid-cbox-output-video.ts")));
     QVERIFY(!QFileInfo::exists(QDir(savePath).filePath("invalid-cbox-output-video.mp4")));
+    // 与 process_failed 一致：cbox 已执行但产物异常时，保留 output.txt 供排查。
+    QVERIFY(QFileInfo::exists(outputPath));
 
     const auto arguments = spy.takeFirst();
     QCOMPARE(arguments.at(0).toBool(), false);


### PR DESCRIPTION
## 一、PR 概述

Fixes #87。

本 PR 强制 Windows CI / release 流程使用 Release 配置，并改进 `cbox.exe` 解密失败时的诊断保留，避免用户只看到泛化的“cbox 退出失败”。同时补充了几项 CI / CMake 实践优化，降低后续维护和排查成本。

---

## 二、背景 / 动机

- **问题现象**：issue #87 中非 4K 视频分片下载和合并成功后，`cbox.exe` 解密阶段退出失败，日志只显示 `exit_code=-1073741819` 和“cbox 退出失败”。
- **影响范围**：Windows release 产物的解密链路，以及后续排查 DRM / cbox 崩溃问题的可观测性。
- **根因方向**：现有发布流程虽然构建主程序使用 Release，但配置没有集中约束；同时解密失败时会清理 `output.txt`，导致 `cbox` / DRM 侧诊断丢失。

---

## 三、改动内容

- Windows release / tag release / test workflow 统一使用 `BUILD_CONFIG=Release`。
- CMake configure 显式限制 Windows release 配置为 `Release`。
- `windeployqt` 按当前构建配置选择 `--debug` 或 `--release`，避免本地 Debug 构建误部署 Release Qt runtime。
- 非发布 workflow 显式使用最小权限 `contents: read`。
- Windows workflows 增加 `timeout-minutes`，避免 Qt 安装或 MSVC 构建异常卡住过久。
- `windows-tests.yml` 保持 Windows-only，避免在 macOS/Linux 上误跑依赖 Windows 二进制的测试。
- `cbox` 进程失败时保留 `output.txt` / `udrmencrypt.log`，并在 stdout/stderr 为空时把它们纳入错误诊断。
- 负退出码增加 NTSTATUS 十六进制展示，例如 `-1073741819/0xC0000005`。
- 增加回归测试覆盖诊断文件兜底和 NTSTATUS 格式化。

**改动类型：**
- [x] 缺陷修复
- [ ] 重构/整理
- [ ] 性能优化
- [ ] 文档更新
- [x] 测试补充
- [x] 依赖/配置变更

---

## 四、实现说明

- **核心思路**：发布和 CI 侧明确只产出 Release 配置；运行时侧保留并展示 `cbox` / DRM 可能写出的诊断文件，方便确认崩溃模块、授权失败、证书/TLS 问题或设备码问题。
- **平台策略**：当前解密链路依赖仓库内 Windows `cbox.exe`、`udrmdecrypt.dll` 和 Windows `ffmpeg.exe`，因此本 PR 不启用 macOS/Linux CI。真正跨平台需要先替换或重构这些解密/工具依赖。
- **CI 实践**：普通 push / PR workflow 使用只读 token；release workflow 仍保留 `contents: write` 用于创建 GitHub Release。
- **主要涉及文件/模块**：
  - `.github/workflows/release.yml`
  - `.github/workflows/windows-release.yml`
  - `.github/workflows/windows-tests.yml`
  - `CMakeLists.txt`
  - `src/source/decryptworker.cpp`
  - `tests/regression_core_tests.cpp`

---

## 五、行为变化（对外影响）

- **之前是**：Windows workflows 存在 Debug/Release 配置混用风险；`cbox` 崩溃时常只显示“cbox 退出失败”，并清理掉 `output.txt`。
- **现在是**：Windows workflows 明确使用 Release；`cbox` 失败时会保留诊断文件，并在错误消息中显示更明确的退出码和诊断内容。
- **兼容性影响**：无 Breaking Change。

---

## 六、测试与验证

**自测结果：**
- [x] 已做 diff 空白检查
- [x] 已解析 workflow YAML
- [x] 已本地配置 CMake Release + 生成 `compile_commands.json`
- [x] 已本地构建 `core_regression_tests`
- [x] 已本地跑本 PR 相关解密诊断测试
- [x] Fork GitHub Actions Windows Release Build 通过
- [x] Fork GitHub Actions Windows Tests 通过

**测试命令 / 步骤：**
```bash
git diff --check
ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |p| YAML.load_file(p); puts "OK #{p}" }'
cmake -S . -B build-local -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt
cmake --build build-local --config Release --target core_regression_tests -j 4
QT_QPA_PLATFORM=offscreen build-local/tests/core_regression_tests \
  decryptWorker_processFailed_prefersStderrAndPreservesDiagnostics \
  decryptWorker_processFailed_fallsBackToDiagnosticFileAndFormatsNtStatus \
  decryptWorker_processFailed_preservesPreExistingLicense
```

说明：macOS 本地完整 `core_regression_tests` 套件中有 5 个既有跨平台环境失败，主要来自本机无法执行仓库内 Windows `ffmpeg.exe`，以及一个取消时序断言；本 PR 相关测试已单独通过。由于解密链路仍依赖 Windows-only 二进制，本 PR 保持 CI 为 Windows-only。

---

## 七、Checklist

- [x] 代码风格符合项目规范
- [x] 已添加/更新测试用例
- [x] 无 Breaking Changes
- [x] 已关联相关 Issue